### PR TITLE
Improve MCP tool field selection and LLM data fetching guidance

### DIFF
--- a/src/lib/mcp-plugin/utils/zod-schema.ts
+++ b/src/lib/mcp-plugin/utils/zod-schema.ts
@@ -36,8 +36,14 @@ export function buildInputZodShape(
           .int()
           .min(0)
           .max(10)
-          .default(1)
+          .default(0)
           .describe('Depth of population for relationships')
+          .optional(),
+        fields: z
+          .array(z.string())
+          .describe(
+            "Optional list of field paths to return (dot notation). Defaults to all top-level fields; 'id' is always included for collections.",
+          )
           .optional(),
       }
 
@@ -51,8 +57,14 @@ export function buildInputZodShape(
           .int()
           .min(0)
           .max(10)
-          .default(1)
+          .default(0)
           .describe('Depth of population for relationships')
+          .optional(),
+        fields: z
+          .array(z.string())
+          .describe(
+            "Optional list of field paths to return (dot notation). Defaults to all top-level fields; 'id' is always included for collections.",
+          )
           .optional(),
       }
 
@@ -80,8 +92,14 @@ export function buildInputZodShape(
           .int()
           .min(0)
           .max(10)
-          .default(1)
+          .default(0)
           .describe('Depth of population for relationships in response')
+          .optional(),
+        fields: z
+          .array(z.string())
+          .describe(
+            "Optional list of field paths to return in response (dot notation). Defaults to all top-level fields; 'id' is always included for collections.",
+          )
           .optional(),
       }
 
@@ -111,8 +129,14 @@ export function buildInputZodShape(
           .int()
           .min(0)
           .max(10)
-          .default(1)
+          .default(0)
           .describe('Depth of population for relationships in response')
+          .optional(),
+        fields: z
+          .array(z.string())
+          .describe(
+            "Optional list of field paths to return in response (dot notation). Defaults to all top-level fields; 'id' is always included for collections.",
+          )
           .optional(),
       }
 


### PR DESCRIPTION
Add field selection and set default depth to 0 for MCP tools to enable LLMs to retrieve only necessary data and avoid heavy nested fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2fe0995-4819-479f-ba38-e72b83c84bc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2fe0995-4819-479f-ba38-e72b83c84bc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

