### PR TITLE
Validate where clause string to json filtering

### DIFF
--- a/src/lib/mcp-plugin/utils/tests/zod-schema.test.ts
+++ b/src/lib/mcp-plugin/utils/tests/zod-schema.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
 
 import type { CollectionAnalysis, FieldAnalysis } from '../../types/index.js'
 
@@ -59,6 +60,14 @@ describe('zod-schema', () => {
         expect(result.limit).toBeDefined()
         expect(result.page).toBeDefined()
         expect(result.depth).toBeDefined()
+      })
+
+      it('should parse string where JSON into object via preprocess', () => {
+        const shape = buildInputZodShape(mockCollectionAnalysis, 'list')
+        // Zod schema shape object: use z.object to validate
+        const schema = (z as any).object(shape)
+        const parsed = schema.parse({ where: '{"title": {"equals": "Hello"}}' })
+        expect(parsed.where).toEqual({ title: { equals: 'Hello' } })
       })
     })
 

--- a/src/lib/mcp-plugin/utils/tool-generator.ts
+++ b/src/lib/mcp-plugin/utils/tool-generator.ts
@@ -300,6 +300,12 @@ function createListTool(
           description: 'Sort field name (prefix with - for descending)',
           examples: ['createdAt', '-updatedAt', 'title'],
         },
+        where: {
+          type: 'object',
+          description:
+            "Query conditions for filtering documents. Clients may send an object or a JSON string; strings are parsed server-side.",
+          additionalProperties: true,
+        },
         fields: {
           type: 'array',
           description:

--- a/src/lib/mcp-plugin/utils/zod-schema.ts
+++ b/src/lib/mcp-plugin/utils/zod-schema.ts
@@ -17,7 +17,7 @@ export function buildInputZodShape(
       return {
         data: z
           .preprocess(
-            (val) => {
+            (val: unknown) => {
               if (typeof val === 'string') {
                 try {
                   return JSON.parse(val)
@@ -101,7 +101,22 @@ export function buildInputZodShape(
           .describe('Page number for pagination (1-based)')
           .optional(),
         sort: z.string().describe('Sort field name (prefix with - for descending)').optional(),
-        where: z.any().describe('Query conditions for filtering documents').optional(),
+        where: z
+          .preprocess(
+            (val: unknown) => {
+              if (typeof val === 'string') {
+                try {
+                  return JSON.parse(val)
+                } catch {
+                  return val
+                }
+              }
+              return val
+            },
+            z.object({}).catchall(z.any()),
+          )
+          .describe('Query conditions for filtering documents (object or JSON string)')
+          .optional(),
         fields: z
           .array(z.string())
           .describe(
@@ -117,7 +132,7 @@ export function buildInputZodShape(
           : { id: z.string().describe('The ID of the document to update') }),
         data: z
           .preprocess(
-            (val) => {
+            (val: unknown) => {
               if (typeof val === 'string') {
                 try {
                   return JSON.parse(val)


### PR DESCRIPTION
## Description

This PR enhances the payload filtering mechanism by ensuring that the `where` parameter in `list` operations correctly parses JSON strings into objects. This allows clients to send `where` conditions as either a JSON object or a JSON string, improving flexibility and usability.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance (dependency updates, build changes, etc.)
- [x] ♻️ Code refactoring (no functional changes - for type fixes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements

## Related Issues

Fixes #

## Changes Made

- Implemented a Zod preprocess for the `where` parameter in `list` operations to automatically parse JSON strings into objects.
- Updated the `createListTool` input schema description to clearly state that `where` accepts both objects and JSON strings.
- Added a unit test to verify the correct parsing of stringified JSON for the `where` parameter.
- Fixed implicit `any` types in Zod preprocess callbacks for improved type safety.

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass locally
- [x] Manual testing completed (verified `where` parsing behavior)
- [x] No breaking changes to existing functionality

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (tool descriptor)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Breaking Changes

N/A

## Additional Notes

This change ensures that the `where` parameter is consistently handled as a JSON object internally, regardless of whether it's provided as a string or an object by the client.
Files touched:
- `src/lib/mcp-plugin/utils/zod-schema.ts`: Added preprocess for `where` and typed callbacks.
- `src/lib/mcp-plugin/utils/tool-generator.ts`: Added `where` to input schema description.
- `src/lib/mcp-plugin/utils/tests/zod-schema.test.ts`: Imported `z` and added a new test case.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4db3568-8602-4f8a-a097-bdc664551e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d4db3568-8602-4f8a-a097-bdc664551e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

