### PR TITLE
Improve draft handling for PayloadCMS

### DIFF
--- a/src/lib/mcp-plugin/tools/base-tools.ts
+++ b/src/lib/mcp-plugin/tools/base-tools.ts
@@ -26,6 +26,7 @@ export const baseTools = (server: McpServer, payload: BasePayload) => {
     async ({ name }) => {
       const collection = await payload.find({
         collection: name,
+        draft: true,
       })
 
       return {
@@ -47,6 +48,7 @@ export const baseTools = (server: McpServer, payload: BasePayload) => {
       const doc = await payload.create({
         collection,
         data,
+        draft: true,
       })
 
       return {
@@ -70,6 +72,7 @@ export const baseTools = (server: McpServer, payload: BasePayload) => {
         const doc = await payload.create({
           collection,
           data: item,
+          draft: true,
         })
         docs.push(doc.id)
       }
@@ -97,6 +100,7 @@ export const baseTools = (server: McpServer, payload: BasePayload) => {
         id,
         collection,
         data,
+        draft: true,
       })
 
       return {
@@ -171,6 +175,7 @@ export const baseTools = (server: McpServer, payload: BasePayload) => {
       const doc = await payload.findByID({
         id,
         collection,
+        draft: true,
       })
 
       return {
@@ -196,6 +201,7 @@ export const baseTools = (server: McpServer, payload: BasePayload) => {
       const originalDoc = await payload.findByID({
         id,
         collection,
+        draft: true,
       })
 
       const { id: _id, createdAt: _createdAt, updatedAt: _updatedAt, ...docData } = originalDoc
@@ -206,6 +212,7 @@ export const baseTools = (server: McpServer, payload: BasePayload) => {
           ...docData,
           ...overrides,
         },
+        draft: true,
       })
 
       return {


### PR DESCRIPTION
## Description

This PR refines the draft functionality for PayloadCMS tools, ensuring that read operations prioritize fetching draft versions when available and that update operations default to creating drafts unless explicitly published. This aligns with PayloadCMS best practices for managing content versions.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance (dependency updates, build changes, etc.)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## Related Issues

Fixes #

## Changes Made

-   **Default Draft Reads**: `isDraft` parameter for `get` and `list` tools now defaults to `true`, ensuring that the latest draft or published version is retrieved.
-   **Default Draft Updates**: Added a `publish` boolean parameter to `update` tools, which defaults to `false`. When `publish` is `false` (or not provided), updates are saved as drafts.
-   **Base Tool Integration**: Modified `base-tools.ts` to explicitly pass `draft: true` for all `find`, `findByID`, `create`, `update`, and `duplicate` operations, ensuring consistent draft preference.
-   **Tool Generator Logic**: Updated `tool-generator.ts` to correctly interpret `isDraft` for reads and `publish` for writes, passing the appropriate `draft` parameter to PayloadCMS.

## Testing

- [ ] Unit tests pass locally
- [ ] Integration tests pass locally
- [x] Manual testing completed
- [x] No breaking changes to existing functionality

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Breaking Changes

N/A

## Additional Notes

These changes ensure that the AI assistant's interactions with PayloadCMS collections and globals will naturally prefer draft versions for reads and create drafts for updates, requiring an explicit `publish: true` to publish content directly. This aligns with a common content management workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-afe75daa-37d5-470b-8780-780dd5d16367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-afe75daa-37d5-470b-8780-780dd5d16367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

